### PR TITLE
Include output when command fails

### DIFF
--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -288,7 +288,10 @@ def run_programs(app, doctree):
         else:
             if returncode != node['returncode']:
                 logger.warning(
-                    'Unexpected return code %s from command %s', returncode, command
+                    'Unexpected return code %s from command %s:\n%s',
+                    returncode,
+                    command,
+                    output,
                 )
 
             # replace lines with ..., if ellipsis is specified


### PR DESCRIPTION
At this moment the errors caused by unexpected return code from
the executed command are opaque and make debugging difficult.

This change adds the output to the message in order to ease debugging.