### PR TITLE
Avoid ellipsis test bug

### DIFF
--- a/src/sphinxcontrib/programoutput/tests/__init__.py
+++ b/src/sphinxcontrib/programoutput/tests/__init__.py
@@ -2,6 +2,8 @@ import os
 import os.path
 import shutil
 import tempfile
+import unittest  # noqa
+
 
 from docutils import nodes
 from docutils.parsers.rst import directives
@@ -13,6 +15,14 @@ from functools import update_wrapper
 # pylint:disable=no-self-use,protected-access,too-few-public-methods
 # useless-object-inheritance is version specific
 # pylint:disable=bad-option-value,useless-object-inheritance
+
+# Trick to avoid unresonable truncation on assertEqual
+# $ https://stackoverflow.com/a/61345284/99834
+# if 'unittest.util' in __import__('sys').modules:
+#     # Show full diff in self.assertEqual.
+#     __import__('sys').modules[
+#         'unittest.util'
+#     ]._MAX_LENGTH = 9999  # pylint: disable=protected-access
 
 
 class Lazy(object):

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -100,7 +100,7 @@ class TestDirective(AppMixin, unittest.TestCase):
         working_directory = working_directory or app.srcdir
         working_directory = os.path.normpath(os.path.realpath(working_directory))
         cache_key = Command(cmd, use_shell, hide_standard_error, working_directory)
-        self.assertEqual(cache, {cache_key: (returncode, output)})
+        self.assertEqual(cache[cache_key], (returncode, output))
 
     @with_content('.. program-output:: echo eggs')
     def test_simple(self):
@@ -481,20 +481,20 @@ U+2264 ≤ LESS-THAN OR EQUAL TO""",
 
     @with_content(
         """\
-    .. program-output:: echo -e "U+2264 ≤ LESS-THAN OR EQUAL TO\\n≤ line2\\n≤ line3"
+    .. program-output:: python -c "print('≤1\\n≤2\\n≤3')"
         :ellipsis: 2
     """
     )
     def test_unicode_output_with_ellipsis(self):
+
         self.assert_output(
             self.doctree,
-            u"""\
-U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n...""",
+            """≤1\n≤2\n...""",
         )
         self.assert_cache(
             self.app,
-            u'echo -e "U+2264 ≤ LESS-THAN OR EQUAL TO\\n≤ line2\\n≤ line3"',
-            u'U+2264 \u2264 LESS-THAN OR EQUAL TO\n\u2264 line2\n\u2264 line3',
+            '''python -c "print('≤1\\n≤2\\n≤3')"''',
+            """≤1\n≤2\n≤3""",
         )
 
     @with_content(


### PR DESCRIPTION
- changes assertEqual to include longer strings on failures
- makes assert_cache test avoid the wrapping dictionary
- avoid bug #6 with echo

Fixes: #6