### PR TITLE
Migrate packaging metadata to setup.cfg

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -24,6 +24,8 @@ jobs:
         include:
           - name: lint
             tox_env: lint
+          - name: packaging
+            tox_env: packaging
           - name: doc
             tox_env: doc
           - name: py36

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ parts/
 doc/_build/
 doc/__pycache__
 doc/relstorage.*.rst
+.eggs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,10 @@ include README.rst
 include LICENSE
 include CHANGES.*
 include tox.ini
-include .travis.yml
 include .coveragerc
+include .pre-commit-config.yaml
 include .pylintrc
+include .travis.yml
+include .yamllint
 recursive-include src *.py
 recursive-include doc *.rst *.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,13 @@
+[build-system]
+requires = [
+  "pip >= 19.3.1",
+  "setuptools >= 42",
+  "setuptools_scm[toml] >= 3.5.0",
+  "setuptools_scm_git_archive >= 1.1",
+  "wheel >= 0.33.6",
+]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 skip-string-normalization = true
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,84 @@
+[metadata]
+name = sphinxcontrib-programoutput
+url = https://sphinxcontrib-programoutput.readthedocs.org/
+project_urls =
+  Bug Tracker = https://github.com/sphinx-contrib/sphinxcontrib-programoutput/issues
+  CI: GitHub = https://github.com/sphinx-contrib/sphinxcontrib-programoutput/actions?query=workflow:gh+branch:master+event:push
+  Documentation = https://sphinxcontrib-programoutput.readthedocs.org/
+  Source Code = https://github.com/sphinx-contrib/sphinxcontrib-programoutput
+description = Sphinx extension to include program output
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+author = Sebastian Wiesner
+author_email = lunaryorn@gmail.com
+maintainer = Jason Madden
+maintainer_email = jason@nextthought.com
+license = BSD
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    License :: OSI Approved :: BSD License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: Implementation :: CPython
+    Topic :: Documentation
+    Topic :: Utilities
+    Framework :: Sphinx
+    Framework :: Sphinx :: Extension
+
+keywords =
+  sphinx
+  cli
+  command
+  output
+  program
+  example
+
+[files]
+namespace_packages =
+    sphinxcontrib
+packages =
+    sphinxcontrib.programoutput
+# data_files =
+#    share/docs = docs/*
+
+[options]
+use_scm_version = True
+python_requires = >=3.6
+package_dir =
+  = src
+packages = find_namespace:
+include_package_data = True
+zip_safe = False
+
+# These are required during `setup.py` run:
+setup_requires =
+    setuptools_scm >= 1.15.0
+    setuptools_scm_git_archive >= 1.0
+
+# These are required in actual runtime:
+install_requires =
+    Sphinx>=1.7.0
+
+# https://github.com/pypa/setuptools/issues/2406
+# Note: presence of older __init__.py inside the namespace root breaks the
+# find.
+[options.packages.find]
+where = src
+
+[options.extras_require]
+test =
+
 [aliases]
 release = egg_info -RDb ''
 
 [upload_docs]
 upload_dir = build/sphinx/html
-
-[bdist_wheel]
-universal = 1
-
-[zest.releaser]
-python-file-with-version = src/sphinxcontrib/programoutput/__init__.py
 
 [flake8]
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -23,77 +23,14 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import os
-import re
-from setuptools import setup, find_packages
+import setuptools
 
 
-def read_desc():
-    with open('README.rst') as stream:
-        readme = stream.read()
-    with open('CHANGES.rst') as stream:
-        changes = stream.read()
-
-    return readme + '\n\n' + changes
-
-
-def read_version_number():
-    VERSION_PATTERN = re.compile(r"__version__ = '([^']+)'")
-    with open(
-        os.path.join('src', 'sphinxcontrib', 'programoutput', '__init__.py')
-    ) as stream:
-        for line in stream:
-            match = VERSION_PATTERN.search(line)
-            if match:
-                return match.group(1)
-
-        raise ValueError('Could not extract version number')
-
-
-tests_require = []
-
-setup(
-    name='sphinxcontrib-programoutput',
-    version=read_version_number(),
-    url='https://sphinxcontrib-programoutput.readthedocs.org/',
-    license='BSD',
-    author='Sebastian Wiesner',
-    author_email='lunaryorn@gmail.com',
-    maintainer="Jason Madden",
-    maintainer_email='jason@nextthought.com',
-    description='Sphinx extension to include program output',
-    long_description=read_desc(),
-    keywords="sphinx cli command output program example",
-    zip_safe=False,
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: CPython",
-        'Topic :: Documentation',
-        'Topic :: Utilities',
-        'Framework :: Sphinx',
-        'Framework :: Sphinx :: Extension',
-    ],
-    platforms='any',
-    packages=find_packages('src'),
-    package_dir={'': 'src'},
-    namespace_packages=['sphinxcontrib'],
-    include_package_data=True,
-    install_requires=[
-        'Sphinx>=1.7.0',
-    ],
-    tests_require=tests_require,
-    extras_require={
-        'test': tests_require,
-    },
-    python_requires=">=3.6",
+"""
     test_suite='sphinxcontrib.programoutput.tests',
+"""
+
+setuptools.setup(
+    use_scm_version={"local_scheme": "no-local-version"},
+    setup_requires=["setuptools_scm[toml]>=3.5.0"],
 )

--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -37,6 +37,7 @@ from __future__ import print_function, division, absolute_import
 
 import sys
 import os
+import pkg_resources
 import shlex
 from subprocess import Popen, PIPE, STDOUT
 from collections import defaultdict, namedtuple
@@ -48,7 +49,11 @@ from docutils.statemachine import StringList
 
 from sphinx.util import logging as sphinx_logging
 
-__version__ = '0.17.dev0'
+try:
+    __version__ = pkg_resources.get_distribution("sphinxcontrib.programoutput").version
+except (pkg_resources.DistributionNotFound, AttributeError):
+    __version__ = "unknown"
+
 
 logger = sphinx_logging.getLogger('contrib.programoutput')
 

--- a/src/sphinxcontrib/programoutput/tests/test_directive.py
+++ b/src/sphinxcontrib/programoutput/tests/test_directive.py
@@ -35,7 +35,7 @@ from docutils.nodes import caption, container, literal_block, system_message
 
 from sphinxcontrib.programoutput import Command
 
-from . import AppMixin
+from sphinxcontrib.programoutput.tests import AppMixin
 
 
 def with_content(content, **kwargs):

--- a/src/sphinxcontrib/programoutput/tests/test_setup.py
+++ b/src/sphinxcontrib/programoutput/tests/test_setup.py
@@ -26,7 +26,7 @@
 from __future__ import print_function, division, absolute_import
 
 import unittest
-from . import AppMixin
+from sphinxcontrib.programoutput.tests import AppMixin
 
 from sphinxcontrib.programoutput import ProgramOutputCache
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py37,py38,doc,coverage
+envlist=py36,py37,py38,doc,coverage,packaging
 
 [testenv]
 usedevelop = true
@@ -10,9 +10,12 @@ deps =
     coverage
     old: Sphinx == 1.7.0
 commands =
-    coverage run -p -m unittest discover -s src
+    coverage run -p -m unittest discover -s src/sphinxcontrib
     pylint -r no src/sphinxcontrib
 passenv = HOME
+whitelist_externals =
+    rm
+    sh
 
 [testenv:coverage]
 commands =
@@ -33,3 +36,30 @@ deps =
     pre-commit >= 2.9.3
 commands =
     pre-commit run -a
+
+[testenv:packaging]
+description =
+    Do packaging/distribution. If tag is not present or PEP440 compliant upload to
+    PYPI could fail
+# `usedevelop = true` overrides `skip_install` instruction, it's unwanted
+usedevelop = false
+# don't install molecule itself in this env
+skip_install = true
+deps =
+    check-manifest
+    collective.checkdocs >= 0.2
+    pep517 >= 0.8.2
+    pip >= 20.2.2
+    toml >= 0.10.1
+    twine >= 3.2.0  # pyup: ignore
+setenv =
+commands =
+    rm -rfv {toxinidir}/dist/
+    python -m check_manifest
+    python -m pep517.build \
+      --source \
+      --binary \
+      --out-dir {toxinidir}/dist/ \
+      {toxinidir}
+    # metadata validation
+    sh -c "python -m twine check {toxinidir}/dist/*"


### PR DESCRIPTION
- moves packaging metadata to setup.cfg
- adopts use of setuptools-scm for dynamic versioning
- adopts PEP-517 guidelines
- adds extra testing for packaging

Related: https://github.com/pypa/setuptools/issues/2406