### PR TITLE
Add basic ANSI  support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ doc/_build/
 doc/__pycache__
 doc/relstorage.*.rst
 .eggs
+.tox

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,4 +54,6 @@ repos:
       - id: pylint
         additional_dependencies:
           - docutils
+          - mock
+          - pytest
           - sphinx

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,6 @@ include .pre-commit-config.yaml
 include .pylintrc
 include .travis.yml
 include .yamllint
-recursive-include src *.py
+include tools/ansitest
+recursive-include src *.py *.css
 recursive-include doc *.rst *.py

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@
 
 import sphinxcontrib.programoutput as programoutput
 
-needs_sphinx = '1.0'
+needs_sphinx = '3.0'
 
 extensions = [
     'sphinx.ext.autodoc',
@@ -51,7 +51,6 @@ html_static_path = []
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org', None),
-    'ansi': ('http://packages.python.org/sphinxcontrib-ansi', None),
 }
 
 extlinks = {

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -18,7 +18,7 @@ Installation
 
 Use ``pip`` to install this extension from PyPI_::
 
-   pip install sphinxcontrib-programoutput
+   pip install sphinxcontrib-programoutput2
 
 The extension requires Sphinx 1.3 and Python 2.7 or Python 3 at least.
 
@@ -147,6 +147,36 @@ Other shell features like process expansion consequently work, too::
 
 Remember to use ``shell`` carefully to avoid unintented interpretation of shell
 syntax and swallowing of fatal errors!
+
+
+ANSI Support
+------------
+
+If you want to inject an ANSI block you use the `ansi-block` directive.
+
+.. directive:: ansi-block
+
+   This directive interprets its content as literal block containing ANSI
+   control sequences for coloured output for HTML output.  If the document
+   is build with any other builder than ``html``, color sequences are
+   stripped from output.
+
+   If the option ``string_escape`` is specified, the content of the
+   directive is decoded using the ``string_escape`` codec.  Thus you can
+   include Python escape sequences, and therefore use ``\x1b`` instead of
+   the real escape character.
+
+.. ansi-block::
+   :string_escape:
+
+   \x1b[31mRed dwarf!\x1b[0m or normal.
+
+If ANSI escapes are detected in output captured by `command-output` or
+`program-output` directives, they are automatically rendered as HTML.
+
+.. command-output:: ./tools/ansitest
+   :shell:
+   :cwd: ..
 
 
 Error handling

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [metadata]
 name = sphinxcontrib-programoutput2
+provides =
+  sphinxcontrib.programoutput
 url = https://sphinxcontrib-programoutput2.readthedocs.org/
 project_urls =
   Bug Tracker = https://github.com/sphinx-contrib/sphinxcontrib-programoutput/issues
@@ -74,6 +76,8 @@ where = src
 
 [options.extras_require]
 test =
+  mock
+  pytest
 
 [aliases]
 release = egg_info -RDb ''
@@ -83,3 +87,10 @@ upload_dir = build/sphinx/html
 
 [flake8]
 max-line-length = 88
+# E203: https://github.com/python/black/issues/315
+ignore = E203
+
+[tool:pytest]
+# We need this because tests are parts of the package and their final location
+# may or may bot be local (editable or non-editable install).
+addopts = --pyargs sphinxcontrib.programoutput

--- a/src/sphinxcontrib/programoutput/ansi.py
+++ b/src/sphinxcontrib/programoutput/ansi.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2010, Sebastian Wiesner <lunaryorn@googlemail.com>
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
+"""
+    sphinxcontrib.ansi
+    ==================
+
+    This extension parses ANSI color codes in literal blocks.
+
+    .. moduleauthor::  Sebastian Wiesner  <lunaryorn@googlemail.com>
+"""
+
+from __future__ import absolute_import, print_function
+import logging
+import os
+from os import path
+import re
+
+from docutils import nodes
+from docutils.parsers import rst
+from docutils.parsers.rst.directives import flag
+from sphinx.util.osutil import copyfile
+
+# DISABLED: from sphinx.util.console import bold
+
+
+__version__ = '0.7.0'
+
+# -- DIAGNOSTIC SUPPORT:
+DIAG = os.environ.get("SPHINXCONTRIB_ANSI_DIAG", "no") == "yes"
+console = logging.getLogger("sphinxcontrib.programoutput")
+console.setLevel(logging.ERROR)
+if DIAG:
+    console.setLevel(logging.INFO)
+
+
+# pylint: disable=too-many-ancestors
+class ansi_literal_block(nodes.literal_block):
+    """
+    Represent a literal block, that contains ANSI color codes.
+    """
+
+
+#: the pattern to find ANSI color codes
+COLOR_PATTERN = re.compile('\x1b\\[([^m]+)m')
+
+#: map ANSI color codes to class names
+CODE_CLASS_MAP = {
+    1: 'bold',
+    4: 'underscore',
+    30: 'black',
+    31: 'red',
+    32: 'green',
+    33: 'yellow',
+    34: 'blue',
+    35: 'magenta',
+    36: 'cyan',
+    37: 'white',
+    40: 'bg_black',
+    41: 'bg_red',
+    42: 'bg_green',
+    43: 'bg_yellow',
+    44: 'bg_blue',
+    45: 'bg_magenta',
+    46: 'bg_cyan',
+    47: 'bg_white',
+    2: 'dim',
+}
+
+
+# see https://stackoverflow.com/a/58829514/99834
+def string_escape(s, encoding='utf-8'):
+    return s.encode('latin1').decode('unicode-escape').encode('latin1').decode(encoding)
+
+
+# pylint: disable=too-few-public-methods
+class ANSIColorParser:
+    """
+    Traverse a document, look for ansi_literal_block nodes, parse these
+    nodes, and replace them with literal blocks, containing proper child
+    nodes for ANSI color sequences.
+    """
+
+    def __init__(self):
+        self.pending_nodes = []
+        self.new_nodes = []
+
+    def _finalize_pending_nodes(self):
+        """
+        Finalize all pending nodes.
+
+        Pending nodes will be append to the new nodes.
+        """
+        self.new_nodes.extend(self.pending_nodes)
+        self.pending_nodes = []
+
+    def _add_text(self, text):
+        """
+        If ``text`` is not empty, append a new Text node to the most recent
+        pending node, if there is any, or to the new nodes, if there are no
+        pending nodes.
+        """
+        if text:
+            if self.pending_nodes:
+                self.pending_nodes[-1].append(nodes.Text(text))
+            else:
+                self.new_nodes.append(nodes.Text(text))
+
+    def _colorize_block_contents(self, block):
+        raw = block.rawsource
+        # create the "super" node, which contains to while block and all it
+        # sub nodes, and replace the old block with it
+        literal_node = nodes.literal_block()
+        literal_node['classes'].append('ansi-block')
+        block.replace_self(literal_node)
+
+        # this contains "pending" nodes.  A node representing an ANSI
+        # color is "pending", if it has not yet seen a reset
+        self.pending_nodes = []
+        # these are the nodes, that will finally be added to the
+        # literal_node
+        self.new_nodes = []
+        # this holds the end of the last regex match
+        last_end = 0
+        # iterate over all color codes
+        console.warning("\nANSI_COLORIZE.block:\n%s\nANSI_COLORIZE.block.end\n", raw)
+
+        for match in COLOR_PATTERN.finditer(raw):
+            # add any text preceeding this match
+            head = raw[last_end : match.start()]
+            self._add_text(head)
+            # update the match end
+            last_end = match.end()
+            # get the single format codes
+            codes = [int(c) for c in match.group(1).split(';')]
+            if codes[-1] == 0:
+                # the last code is a reset, so finalize all pending
+                # nodes.
+                self._finalize_pending_nodes()
+            else:
+                # create a new color node
+                code_node = nodes.inline()
+                self.pending_nodes.append(code_node)
+                # and set the classes for its colors
+                # remove bright bit as we do not support it yet
+                for code in codes:
+                    # code = code & ~(1 << 6)
+                    # import sys
+                    # print(555, code, file=sys.stderr)
+                    if code in CODE_CLASS_MAP:
+                        code_node['classes'].append('ansi-%s' % CODE_CLASS_MAP[code])
+                    else:
+                        console.error("Unknown ANSI code %s found, ignored.", code)
+
+        # add any trailing text
+        tail = raw[last_end:]
+        self._add_text(tail)
+        # move all pending nodes to new_nodes
+        self._finalize_pending_nodes()
+        # and add the new nodes to the block
+        literal_node.extend(self.new_nodes)
+
+    # pylint: disable=no-self-use
+    def _strip_color_from_block_content(self, block):
+        content = COLOR_PATTERN.sub('', block.rawsource)
+        literal_node = nodes.literal_block(content, content)
+        block.replace_self(literal_node)
+
+    def __call__(self, app, doctree, docname):
+        """
+        Extract and parse all ansi escapes in ansi_literal_block nodes.
+        """
+        handler = self._colorize_block_contents
+        if app.builder.name != 'html':
+            # strip all color codes in non-html output
+            handler = self._strip_color_from_block_content
+        for ansi_block in doctree.traverse(ansi_literal_block):
+            handler(ansi_block)
+
+
+def add_stylesheet(app):
+    app.add_css_file('ansi.css')
+
+
+def copy_stylesheet(app, exception):
+    if app.builder.name != 'html' or exception:
+        return
+
+    verbose = hasattr(app, 'info')
+    stylesheet = app.config.html_ansi_stylesheet
+    if stylesheet:
+        if verbose:
+            # DISABLED; app.info(bold('Copying ansi stylesheet... '), nonl=True)
+            app.info('Copying ansi stylesheet... ', nonl=True)
+        dest = path.join(app.builder.outdir, '_static', 'ansi.css')
+        source = path.abspath(path.dirname(__file__))
+        copyfile(path.join(source, stylesheet), dest)
+        if verbose:
+            app.info('done')
+
+
+class ANSIBlockDirective(rst.Directive):
+    """
+    This directive interprets its content as literal block with ANSI color
+    codes.
+
+    The content is decoded using ``string-escape`` to allow symbolic names
+    as \x1b being used instead of the real escape character.
+    """
+
+    has_content = True
+
+    option_spec = dict(string_escape=flag)
+
+    def run(self):
+        text = '\n'.join(self.content)
+        if 'string_escape' in self.options:
+            text = string_escape(text)
+        return [ansi_literal_block(text, text)]
+
+
+def setup(app):
+    app.require_sphinx('1.0')
+    app.add_config_value('html_ansi_stylesheet', None, 'env')
+    app.add_directive('ansi-block', ANSIBlockDirective)
+    app.connect('builder-inited', add_stylesheet)
+    app.connect('build-finished', copy_stylesheet)
+    app.connect('doctree-resolved', ANSIColorParser())
+
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/src/sphinxcontrib/programoutput/black-on-white.css
+++ b/src/sphinxcontrib/programoutput/black-on-white.css
@@ -1,0 +1,104 @@
+.ansi-block {
+    background-color: #ffffff;
+    color: #000000;
+}
+
+.ansi-bold {
+    font-weight: bold;
+}
+
+.ansi-black {
+    color: #000000;
+}
+
+.ansi-red {
+    color: #b21717;
+}
+
+.ansi-green {
+    color: #17b217;
+}
+
+.ansi-yellow {
+    color: #b26717;
+}
+
+.ansi-blue {
+    color: #1717b2;
+}
+
+.ansi-magenta {
+    color: #b217b2;
+}
+
+.ansi-cyan {
+    color: #17b2b2;
+}
+
+.ansi-white {
+    color: #b2b2b2;
+}
+
+.ansi-black.ansi-bold {
+    color: #686868;
+}
+
+.ansi-red.ansi-bold {
+    color: #ff5454;
+}
+
+.ansi-green.ansi-bold {
+    color: #54ff54;
+}
+
+.ansi-yellow.ansi-bold {
+    color: #ffff54;
+}
+
+.ansi-blue.ansi-bold {
+    color: #5454ff;
+}
+
+.ansi-magenta.ansi-bold {
+    color: #ff54ff;
+}
+
+.ansi-cyan.ansi-bold {
+    color: #54ffff;
+}
+
+.ansi-white.ansi-bold {
+    color: #ffffff;
+}
+
+.ansi-bg_black {
+    background-color: #000000;
+}
+
+.ansi-bg_red {
+    background-color: #b21717;
+}
+
+.ansi-bg_green {
+    background-color: #17b217;
+}
+
+.ansi-bg_yellow {
+    background-color: #b26717;
+}
+
+.ansi-bg_blue {
+    background-color: #1717b2;
+}
+
+.ansi-bg_magenta {
+    background-color: #b217b2;
+}
+
+.ansi-bg_cyan {
+    background-color: #17b2b2;
+}
+
+.ansi-bg_white {
+    background-color: #b2b2b2;
+}

--- a/src/sphinxcontrib/programoutput/tests/test_ansi.py
+++ b/src/sphinxcontrib/programoutput/tests/test_ansi.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# SEE: https://github.com/sphinx-doc/sphinx/
+# pylint: disable=redefined-outer-name
+from __future__ import absolute_import, print_function
+
+from docutils import nodes
+from mock import Mock
+import pytest
+
+from sphinxcontrib.programoutput import ansi
+
+
+RAWSOURCE = '''\
+\x1b[1mfoo\x1b[33;1mbar\x1b[1;34mhello\x1b[0mworld\x1b[1m'''
+
+
+# -----------------------------------------------------------------------------
+# FIXTURES:
+# -----------------------------------------------------------------------------
+@pytest.fixture
+def paragraph():
+    par = nodes.paragraph()
+    par.append(ansi.ansi_literal_block(RAWSOURCE, RAWSOURCE))
+    return par
+
+
+@pytest.fixture
+def app():
+    return Mock()
+
+
+@pytest.fixture
+def parser():
+    return ansi.ANSIColorParser()
+
+
+# -----------------------------------------------------------------------------
+# TEST SUPPORT:
+# -----------------------------------------------------------------------------
+def _assert_colors(node, *colors):
+    assert isinstance(node, nodes.inline)
+    for color in colors:
+        assert 'ansi-%s' % color in node['classes']
+
+
+def _assert_text(node, text):
+    assert isinstance(node, nodes.Text)
+    assert node.astext() == text
+
+
+# -----------------------------------------------------------------------------
+# TEST SUITE:
+# -----------------------------------------------------------------------------
+def test_parser_strip_colors(app, parser, paragraph):
+    app.builder.name = 'foo'
+    parser(app, paragraph, 'foo')
+    assert isinstance(paragraph[0], nodes.literal_block)
+    _assert_text(paragraph[0][0], 'foobarhelloworld')
+    assert not paragraph[0][0].children
+    assert paragraph.astext() == 'foobarhelloworld'
+
+
+def test_parser_colors_parsed(app, parser, paragraph):
+    app.builder.name = 'html'
+    parser(app, paragraph, 'foo')
+    block = paragraph[0]
+    assert isinstance(block, nodes.literal_block)
+    _assert_colors(block[0], 'bold')
+    _assert_text(block[0][0], 'foo')
+    _assert_colors(block[1], 'bold', 'yellow')
+    _assert_text(block[1][0], 'bar')
+    _assert_colors(block[2], 'bold', 'blue')
+    _assert_text(block[2][0], 'hello')
+    _assert_text(block[3], 'world')
+    _assert_colors(block[4], 'bold')
+    assert not block[4].children
+    assert paragraph.astext() == 'foobarhelloworld'
+
+
+def test_setup(app):
+    ansi.setup(app)
+    app.require_sphinx.assert_called_with('1.0')
+    app.add_config_value.assert_called_with('html_ansi_stylesheet', None, 'env')
+    app.add_directive.assert_called_with('ansi-block', ansi.ANSIBlockDirective)
+    assert app.connect.call_args_list[:2] == [
+        (('builder-inited', ansi.add_stylesheet),),
+        (('build-finished', ansi.copy_stylesheet),),
+    ]
+    assert app.connect.call_args_list[2][0][0] == 'doctree-resolved'
+    assert isinstance(app.connect.call_args_list[2][0][1], ansi.ANSIColorParser)

--- a/src/sphinxcontrib/programoutput/tests/test_cache.py
+++ b/src/sphinxcontrib/programoutput/tests/test_cache.py
@@ -31,8 +31,7 @@ import sys
 import unittest
 
 from sphinxcontrib.programoutput import ProgramOutputCache, Command
-
-from . import AppMixin
+from sphinxcontrib.programoutput.tests import AppMixin
 
 
 class TestCache(AppMixin, unittest.TestCase):

--- a/tools/ansitest
+++ b/tools/ansitest
@@ -1,0 +1,16 @@
+#!/bin/bash
+text="xYz"; # Some test text
+
+echo -e "\n                40m   41m   42m   43m   44m   45m   46m   47m";
+
+for FGs in '   0m' '   1m' '  30m' '1;30m' '  31m' '1;31m' '  32m' \
+           '1;32m' '  33m' '1;33m' '  34m' '1;34m' '  35m' '1;35m' \
+           '  36m' '1;36m' '  37m' '1;37m'; do
+    FG=${FGs// /}
+    echo -en " $FGs \033[$FG  ${text}  ";
+    for BG in 40m 41m 42m 43m 44m 45m 46m 47m; do
+        echo -en "$EINS \033[$FG\033[${BG} ${text} \033[0m";
+    done
+    echo;
+done
+echo;

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,16 @@
 envlist=py{36,37,38,39},doc,coverage,packaging
 
 [testenv]
-usedevelop = true
+# temporary disabled editable install (usedevelop) due to
+# https://github.com/pypa/pip/issues/8988
+usedevelop = false
 extras =
     test
 deps =
     coverage
     old: Sphinx == 1.7.0
 commands =
-    coverage run -p -m unittest discover -s src/sphinxcontrib
+    coverage run -p -m pytest
 passenv = HOME
 whitelist_externals =
     rm
@@ -25,8 +27,8 @@ parallel_show_output = true
 
 [testenv:doc]
 commands =
-    sphinx-build -W -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
-    sphinx-build -W -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
+    sphinx-build -WT -b linkcheck -d {envtmpdir}/doctrees doc {envtmpdir}/linkcheck
+    sphinx-build -WT -b html -d {envtmpdir}/doctrees doc {envtmpdir}/html
 
 [testenv:lint]
 skipsdist = true


### PR DESCRIPTION
- Adds initial ANSI support based on old ANSI extension
- Switches test runner to use pytest because ANSI tests were already
  using pytest.
- Temporary disables editable installations due to https://github.com/pypa/pip/issues/8988