### PR TITLE
Assure environment is passed

### DIFF
--- a/src/sphinxcontrib/programoutput/__init__.py
+++ b/src/sphinxcontrib/programoutput/__init__.py
@@ -205,6 +205,7 @@ class Command(_Command):
             stdout=PIPE,
             stderr=PIPE if self.hide_standard_error else STDOUT,
             cwd=self.working_directory,
+            env=os.environ,
         )
 
     def get_output(self):


### PR DESCRIPTION
Avoid bug where the called subprocess did not reuse the environment from the sphinx process.